### PR TITLE
Add coverity action

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,18 @@
+name: Coverity Scan
+permissions: read-all
+on:
+  push:
+    branches: [main]
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: git ls-files > git-ls-files.lst
+      - uses: vapier/coverity-scan-action@v1
+        with:
+          project: Evalplus_Gaudi
+          email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          build_language: other
+          command: "--no-command --fs-capture-list git-ls-files.lst"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,7 +2,7 @@ name: Coverity Scan
 permissions: read-all
 on:
   push:
-    branches: [main]
+    branches: [master, main]
 jobs:
   coverity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We will need to set the COVERITY_SCAN_TOKEN and COVERITY_SCAN_EMAIL (for Coverity to send email alerts to) as secrets in your github repo, then this scan should run automatically on every change to "main" or "master" branch, looking for anything being leaked. 